### PR TITLE
Add support for enable_automatic_and_manual_headroom field

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,10 +109,11 @@ resource "spotinst_ocean_ecs" "ocean_ecs" {
 
   ## Autoscaler Settings ##
   autoscaler {
-    is_enabled               = var.autoscaler_is_enabled
-    is_auto_config           = var.autoscaler_is_auto_config
-    auto_headroom_percentage = var.auto_headroom_percentage
-    cooldown                 = var.cooldown
+    is_enabled                           = var.autoscaler_is_enabled
+    is_auto_config                       = var.autoscaler_is_auto_config
+    auto_headroom_percentage             = var.auto_headroom_percentage
+    enable_automatic_and_manual_headroom = var.enable_automatic_and_manual_headroom
+    cooldown                             = var.cooldown
     headroom {
       cpu_per_unit    = var.cpu_per_unit
       memory_per_unit = var.memory_per_unit

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,13 @@ variable "auto_headroom_percentage" {
   default     = null
   description = "The auto-headroom percentage. Set a number between 0-200 to control the headroom % of the cluster. Relevant when isAutoConfig= true."
 }
+
+variable "enable_automatic_and_manual_headroom" {
+  type        = bool
+  default     = false
+  description = "When set to true, both automatic and per custom launch specification manual headroom to be saved concurrently and independently in the cluster. prerequisite: autoscaler_is_auto_config must be true."
+}
+
 ###################
 
 ## Update Policy ##


### PR DESCRIPTION
We need this field set when we use both manual and automatic head room. So, we will be using this fork until this change is merged upstream.